### PR TITLE
Fix OpenGL rendering by installing missing SW rendering library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
         language-pack-zh-hant language-pack-gnome-zh-hant firefox-locale-zh-hant libreoffice-l10n-zh-tw \
         nginx \
         python-pip python-dev build-essential \
+        mesa-utils libgl1-mesa-dri \
     && apt-get autoclean \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I tried installing some of my SW on the container and couldn't get xvfb to render OpenGL windows. This problem can be easily reproduced with the utility `glxdemo` (provided by package `mesa-tools`).

The additional package `libgl1-mesa-dri` is required in order to install `/usr/lib/x86_64-linux-gnu/dri/swrast_dri.so` in the container.