### PR TITLE
Supervisord: running without full path

### DIFF
--- a/rootfs/startup.sh
+++ b/rootfs/startup.sh
@@ -69,4 +69,4 @@ fi
 PASSWORD=
 HTTP_PASSWORD=
 
-exec /bin/tini -- /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
+exec /bin/tini -- supervisord -n -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
supervisord is now running just as supervisord instead of full path (in some Ubuntu 18.04 distros it lyes in other dirs than /usr/bin)

I've inherited this image from nvcr.io/nvidia/tensorflow:19.07-py3, and there supervisord is in /usr/local/bin