### PR TITLE
Have set_size use color depth of 24

### DIFF
--- a/rootfs/usr/local/lib/web/backend/vnc/state.py
+++ b/rootfs/usr/local/lib/web/backend/vnc/state.py
@@ -65,7 +65,7 @@ class State(object):
             'sed -i \'s#'
             '^exec /usr/bin/Xvfb.*$'
             '#'
-            'exec /usr/bin/Xvfb :1 -screen 0 {}x{}x16'
+            'exec /usr/bin/Xvfb :1 -screen 0 {}x{}x24'
             '#\' /usr/local/bin/xvfb.sh'
         ).format(w, h), shell=True)
         self.size_changed_count += 1


### PR DESCRIPTION
As the default color depth in `xvfb.sh` is 24, updates via `set_size` should also use 24. Currently, it is 16 and that messes up some Java GUIs, e.g. http://www.sql-workbench.eu/