### PR TITLE
Re-enable /resize URI

### DIFF
--- a/rootfs/etc/nginx/sites-enabled/default
+++ b/rootfs/etc/nginx/sites-enabled/default
@@ -18,7 +18,7 @@ server {
 	#_RELATIVE_URL_ROOT_	root /usr/local/lib/web/frontend/;
 	#_RELATIVE_URL_ROOT_}
 
-	location ~ .*/(api/.*|websockify) {
+	location ~ .*/(api/.*|websockify|resize) {
 		try_files $uri @api$http_upgrade;
 	}
 


### PR DESCRIPTION
The `/resize` URI is not available in Ubuntu 20.04 images.

![Screenshot from 2021-05-27 09-17-04](https://user-images.githubusercontent.com/3256629/119746841-58f52a00-becc-11eb-83fd-ddba5aee9891.png)

Was this feature removed intentionally?

It seems to have been removed by this commit.

https://github.com/fcwu/docker-ubuntu-vnc-desktop/commit/9d7362e87c905a8a85fae9dfa11001d52a2acaac#diff-9aad1b6e80474f12ae78ba75bc855210d2d7e06c6718fde79b945901dd0177c7

If the deletion was unintentional, then I think it's a glitch, so I wish you could check this PR out.
If its not, please make a note in the README.md that the resize URI has been removed.